### PR TITLE
Upgrade @paypal/paypal-server-sdk from 0.5.x to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@paypal/paypal-server-sdk": "^0.5.1",
+        "@paypal/paypal-server-sdk": "^1.1.0",
         "express": "^4.21.2"
       },
       "engines": {
@@ -177,15 +177,16 @@
       }
     },
     "node_modules/@paypal/paypal-server-sdk": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@paypal/paypal-server-sdk/-/paypal-server-sdk-0.5.2.tgz",
-      "integrity": "sha512-ad+m/1uYuvQY94NA7n1nuQFjWpKZEB7UJPpWfY/0BTF80cLxkWykQs4uizOEIcRQOdQ5PZBlM3R33WOsPqv1ww==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-server-sdk/-/paypal-server-sdk-1.1.0.tgz",
+      "integrity": "sha512-MaJQmSVpQb5nEeZWZDTtGRxeaHj6O51G9Olmm3zQ5E4XNgR4emAI08CKC2ZPhBldVoxAoBVjLyvKjGV5lC1n2Q==",
+      "license": "MIT",
       "dependencies": {
         "@apimatic/authentication-adapters": "^0.5.4",
-        "@apimatic/axios-client-adapter": "^0.3.4",
-        "@apimatic/core": "^0.10.14",
-        "@apimatic/oauth-adapters": "^0.4.6",
-        "@apimatic/schema": "^0.7.12"
+        "@apimatic/axios-client-adapter": "^0.3.7",
+        "@apimatic/core": "^0.10.16",
+        "@apimatic/oauth-adapters": "^0.4.8",
+        "@apimatic/schema": "^0.7.14"
       },
       "engines": {
         "node": ">=14.17.0"
@@ -214,9 +215,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1176,15 +1178,15 @@
       }
     },
     "@paypal/paypal-server-sdk": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@paypal/paypal-server-sdk/-/paypal-server-sdk-0.5.2.tgz",
-      "integrity": "sha512-ad+m/1uYuvQY94NA7n1nuQFjWpKZEB7UJPpWfY/0BTF80cLxkWykQs4uizOEIcRQOdQ5PZBlM3R33WOsPqv1ww==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-server-sdk/-/paypal-server-sdk-1.1.0.tgz",
+      "integrity": "sha512-MaJQmSVpQb5nEeZWZDTtGRxeaHj6O51G9Olmm3zQ5E4XNgR4emAI08CKC2ZPhBldVoxAoBVjLyvKjGV5lC1n2Q==",
       "requires": {
         "@apimatic/authentication-adapters": "^0.5.4",
-        "@apimatic/axios-client-adapter": "^0.3.4",
-        "@apimatic/core": "^0.10.14",
-        "@apimatic/oauth-adapters": "^0.4.6",
-        "@apimatic/schema": "^0.7.12"
+        "@apimatic/axios-client-adapter": "^0.3.7",
+        "@apimatic/core": "^0.10.16",
+        "@apimatic/oauth-adapters": "^0.4.8",
+        "@apimatic/schema": "^0.7.14"
       }
     },
     "accepts": {
@@ -1207,9 +1209,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "start": "node server.js"
   },
   "engines": {
-      "npm": "8.x",
-      "node": "18.x"
+    "npm": "8.x",
+    "node": "18.x"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@paypal/paypal-server-sdk": "^0.5.1",
+    "@paypal/paypal-server-sdk": "^1.1.0",
     "express": "^4.21.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ app.get('/client_id', async (req, res) => {
 
 app.get('/orders/:orderID', async (req, res, next) => {
     try {
-        const response = await ordersController.ordersGet({
+        const response = await ordersController.getOrder({
             id: req.params.orderID
         })
         res.status(200).send(response.body)
@@ -61,7 +61,7 @@ app.get('/orders/:orderID', async (req, res, next) => {
 
 app.post('/orders/:orderID/authorize', async (req, res) => {
     try {
-        const response = await ordersController.ordersAuthorize({
+        const response = await ordersController.authorizeOrder({
             id: req.params.orderID,
             paypalClientMetadataId: req.header('PayPal-Client-Metadata-Id')
         })
@@ -75,7 +75,7 @@ app.post('/orders/:orderID/authorize', async (req, res) => {
 
 app.post('/orders/:orderID/capture', async (req, res) => {
     try {
-        const response = await ordersController.ordersCapture({
+        const response = await ordersController.captureOrder({
             id: req.params.orderID,
             paypalClientMetadataId: req.header('PayPal-Client-Metadata-Id')
         })
@@ -93,7 +93,7 @@ app.post('/orders', async (req, res) => {
             body: req.body,
             paypalClientMetadataId: req.header('PayPal-Client-Metadata-Id')
         };
-        const response = await ordersController.ordersCreate(payload);
+        const response = await ordersController.createOrder(payload);
 
         res.set('Content-Type', 'application/json');
         res.status(201).send(response.body);


### PR DESCRIPTION
- Updated package.json dependency from ^0.5.1 to ^1.1.0
- Updated API method calls to match 1.x interface:
  - ordersGet → getOrder
  - ordersCreate → createOrder
  - ordersCapture → captureOrder
  - ordersAuthorize → authorizeOrder
- Verified server startup and functionality with new SDK version

🤖 Generated with [Claude Code](https://claude.ai/code)